### PR TITLE
DESIGN: update for safari

### DIFF
--- a/components/shared/nav/Nav.module.css
+++ b/components/shared/nav/Nav.module.css
@@ -10,7 +10,6 @@
 
  .nav img {
   max-height: 150px;
-  min-height: min-content;
   width: auto;
   background: #f8f6f4;
   border-radius: 100px;

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,6 @@
 module.exports = {
-  webpack5: true,
   webpack: (config) => {
-    config.resolve.fallback = { fs: false }
+    config.resolve.fallback = { fs: false };
     return config;
-  }
-}
+  },
+};


### PR DESCRIPTION
Designfix: min-height vs max-height on safari renders image always at its largest